### PR TITLE
Improve README with Mac OS X link and clearer link to mockups

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Other Linux distributions may be supported in the future. In the meantime, you c
 
 Mac
 ---
-TBD, preparing release.
+[Harp GUI 1.0.0rc1 64-bit](https://drive.google.com/folderview?id=0BwfNEizpnybJVTVGOHZ3eDR1Y2M&usp=sharing)
 
 Windows
 -------

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ This software is licensed under GPLv3. See the `LICENSE` file for the complete l
 Other Notes
 ===========
 
-Mockups provided by Teto Querini. View them [here](https://drive.google.com/folderview?id=0BwfNEizpnybJVGQ4T1UxMlIwQUU&usp=sharing).
+[Mockups](https://drive.google.com/folderview?id=0BwfNEizpnybJVGQ4T1UxMlIwQUU&usp=sharing) provided by Teto Querini.


### PR DESCRIPTION
@alexgleason mentioned that OS X users can download a build via Google Drive and provided the link via the [Harp GUI issue](https://github.com/sintaxi/harp/issues/507#issuecomment-156745425).

I added this to the README so that it is more accessible.

I also touched up a "here" link to improve usability of the README. This follows a general web developer tip as provided in an article from the W3C: [Don't use "click here" as link text](http://www.w3.org/QA/Tips/noClickHere).